### PR TITLE
Adds promise support when no cb provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,15 @@ var tulind = require(binding_path);
 var make_call = function(ind) {
   var index = ind.index;
   return function(inputs, options, callback) {
-    return tulind.callbyindex(index, inputs, options, callback);
+    if (arguments.length < 3) {
+      return new Promise(function(resolve, reject) {
+        tulind.callbyindex(index, inputs, options, function(err, result) {
+          return err ? reject(err) : resolve(result);
+        });
+      });
+    } else {
+      return tulind.callbyindex(index, inputs, options, callback);
+    }
   };
 };
 

--- a/test.js
+++ b/test.js
@@ -47,7 +47,15 @@ l.run("array sma", function() {
       l.ok(equal(results[0], [2.5,3.5,4.5,5.5,6.5,7.5,8.5]));
     });
 
+    tulind.indicators.sma.indicator([a], [4]).then(function(results) {
+      l.ok(equal(results[0], [2.5,3.5,4.5,5.5,6.5,7.5,8.5]));
+    });
+
     tulind.indicators.sma.indicator([a], [10], function(err, results) {
+      l.ok(equal(results[0], [5.5]));
+    });
+
+    tulind.indicators.sma.indicator([a], [10]).then(function(results) {
       l.ok(equal(results[0], [5.5]));
     });
 
@@ -95,4 +103,3 @@ l.run("array wilders", function() {
 
 
 process.exit(l.results());
-


### PR DESCRIPTION
Hello,

I came across your package and it works well. I'm using node 8 and didn't really want to use callback parameter.

Added support for promise return if callback not provided. Dunno how you feel about it but thought I would just throw the PR up here.

```javascript
// w/callback
tulind.indicators.sma.indicator([close], [9], (err, result) => {
  // Do stuff with value
});

// w/promise
tulind.indicators.sma.indicator([close], [9]).then((result) => {
  // Do stuffsz
});

// w/async-await (which I wanted)
const result = await tulind.indicators.sma.indicator([close], [9]);
```