### PR TITLE
Update node-pre-gyp version to 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     - NODE_VERSION="7"
     - NODE_VERSION="8"
     - NODE_VERSION="9"
+    - NODE_VERSION="10"
+    - NODE_VERSION="11"
 
 sudo: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
     - nodejs_version: 7
     - nodejs_version: 8
     - nodejs_version: 9
+    - nodejs_version: 10
+    - nodejs_version: 11
 
 platform:
     - x64

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bindings": "^1.3.0",
     "nan": "^2.10.0",
-    "node-pre-gyp": "^0.10.3",
+    "node-pre-gyp": "^0.12.0",
     "minctest": "0.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
It fixes build errors caused by the bug mapbox/node-pre-gyp#391 on NodeJs 10

