### PR TITLE
Move to GCC 9 to build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+      - g++-9
 
 before_install:
   - export CXX=g++
   - export CC=gcc
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX=g++-4.8; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC=gcc-9 CXX=g++-9; fi
   - rm -rf ~/.nvm/ && git clone --depth 1 https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh
   - nvm install $NODE_VERSION


### PR DESCRIPTION
Move to GCC 9 to build on Travis (it is the default GCC version bundled with the LTS version of Ubuntu 20.04). 

This resolves the error from the Travis log https://app.travis-ci.com/github/TulipCharts/tulipnode/jobs/529812363#L330 as the command is not available before g++  version 4.9 . 

> g++-4.8: error: unrecognized command line option ‘-std=gnu++14’

References:
https://github.com/nodejs/node/pull/37935
https://stackoverflow.com/questions/39871129/c-error-unrecognized-command-line-option-std-gnu14