### PR TITLE
ci: run test on focal for python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-9
-      - python2.7
 
 before_install:
   - export CXX=g++
@@ -40,6 +39,7 @@ before_install:
   - nvm install $NODE_VERSION
   - nvm use $NODE_VERSION
   - export PATH=$(pwd)/node_modules/.bin:${PATH}
+  - npm install -g npm@6
 
 install:
   - npm install --build-from-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
   - osx
 
+dist: focal
+
 env:
   matrix:
     - NODE_VERSION="10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-9
+      - python2.7
 
 before_install:
   - export CXX=g++


### PR DESCRIPTION
This PR fixes Travis error caused by an obsoleted npm version and missing python 3.6 executable. 