### PR TITLE
ci: add node v18 builds to ci build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 
 dist: focal
+osx_image: xcode14
 
 env:
   matrix:
@@ -16,6 +17,7 @@ env:
     - NODE_VERSION="15"
     - NODE_VERSION="16"
     - NODE_VERSION="17"
+    - NODE_VERSION="18"
 
   global:
     - secure: "qcCCx495V8ocKfd2fRhhbWR61rVdBBf2SVcAIhKQuGc/UluzoT4ctAEqs9J6C0bBW//wPFE6xwaegQ27+e6bcOqwSjKHFDOb+P75/qMqagVms+iftEbLlXQQrZPu7sT8uLb8Aqll+fz5UrgZuEZV1zS92rwKqEcchlbHYRWNbRUPWmItiUZdxxYL3bt7M8RwMBFals7iaqRrru4urSaWHscbZ5czGewfRXW4w1uT6Q9+52QH07SH/zJMppGrSFJKO3Bk7vQgo+657T7sw5pGKjH1JX/jUpKCKDelgPZ48E/ZV1bNsmMoH5tcNKBEJQmJBfFZjdvTWvZ4Huwk9Lyc5i3OREWD4v4qDGPDs36lVBnLjnBvkekpWkxRa7O87hQ77v5LU17f7pwEFBntYm/MQdBJshyxiivDQIf7VqByeuUTn370tOZ3DqZpwtCyFJRcLFLxp3rSXsC+zR0HeW3/bS5EVNByTHy4FHefkCMO3mCMj7miQ7X5fwixxDDl+srzHsR3rvQkMlpPMvBvSWul+tznAJV+N3cK7KrV3tT1PRYBi+pzA5JnBoSMdfF0BhWaPnf7YN53vy62GB8oy0azEb0AHmXCX1p6RcS5iNM44mk8GCXYKz8le1wmlYodSgo/hMxuOc9JnAlgsbhRexTYpErlfOUs58RdNDf1ImO54U4="
@@ -35,12 +37,11 @@ before_install:
   - export CXX=g++
   - export CC=gcc
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC=gcc-9 CXX=g++-9; fi
-  - rm -rf ~/.nvm/ && git clone --depth 1 https://github.com/creationix/nvm.git ~/.nvm
+  - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
   - source ~/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use $NODE_VERSION
-  - export PATH=$(pwd)/node_modules/.bin:${PATH}
-  - npm install -g npm@6
+  - nvm install-latest-npm
 
 install:
   - npm install --build-from-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,9 @@ env:
 
 sudo: false
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-9
-
 before_install:
   - export CXX=g++
   - export CC=gcc
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC=gcc-9 CXX=g++-9; fi
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
   - source ~/.nvm/nvm.sh
   - nvm install $NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,17 @@ env:
 
 sudo: false
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-9
+
 before_install:
   - export CXX=g++
   - export CC=gcc
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC=gcc-9 CXX=g++-9; fi
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
   - source ~/.nvm/nvm.sh
   - nvm install $NODE_VERSION

--- a/Readme.md
+++ b/Readme.md
@@ -19,8 +19,8 @@ Installation should just be:
 npm install tulind
 ```
 
-It should work on Windows, Os X, and Linux. Node version 10, 11, 12, 13, 14 (LTS),
-15 and 16 are tested and supported on each platform.
+It should work on Windows, Os X, and Linux. Node version 10+ and LTS are
+tested and supported on each platform.
 
 Note that pre-compiled binaries are available for Windows. For other platforms
 you will need a C++ build environment installed. On Linux based distributions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
     - nodejs_version: 15
     - nodejs_version: 16
     - nodejs_version: 17
+    - nodejs_version: 18
 
 platform:
     - x64
@@ -26,8 +27,6 @@ shallow_clone: true
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
-  # npm 6.x is the latest version bundled with Node LTS 14.x
-  - npm install -g npm@6
   - ps: $env:path = $env:appdata + "\npm;" + $env:path
 
   # work around an issue with node-gyp v3.3.1 and node 4x

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ shallow_clone: true
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
+  # npm 6.x is the latest version bundled with Node LTS 14.x
+  - npm install -g npm@6
   - ps: $env:path = $env:appdata + "\npm;" + $env:path
 
   # work around an issue with node-gyp v3.3.1 and node 4x

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "bindings": "^1.5.0",
         "nan": "^2.16.0",
-        "@mapbox/node-pre-gyp": "^1.0.5",
+        "@mapbox/node-pre-gyp": "^1.0.x",
         "minctest": "0.0.x"
     },
     "devDependencies": {


### PR DESCRIPTION
Changes:
- added node v18 to the ci build matrix
- install nvm properly on travis (the "official" way)
- `xcode14` is needed for Travis to pass on `macos` with node v18
- use the latest node-pre-gyp version `^1.0.x` 

This is currently blocked by the lack of availability of node 18 x86 binary on the AppVeyor image, which is ultimately cuased by https://nodejs.org/en/blog/announcements/v18-release-announce/

> Prebuilt binaries for 32-bit Windows will initially not be available due to issues building the V8 dependency in Node.js. We hope to restore 32-bit Windows binaries for Node.js 18 with a future V8 update.